### PR TITLE
修復 docker 安裝有機率出現 404 的問題

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -2,8 +2,7 @@ FROM ubuntu:22.04
 
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 RUN sed 's@archive.ubuntu.com@free.nchc.org.tw@' -i /etc/apt/sources.list
-RUN apt-get update
-RUN apt-get install -y ssh python3 python3-pip git build-essential
+RUN apt-get update && apt-get install -y ssh python3 python3-pip git build-essential
 
 RUN mkdir /etc/nuoj
 COPY . /etc/nuoj


### PR DESCRIPTION
## What's new?

在這份 PR 中，我將 docker 安裝有機率 404 的問題排除。

實作上，將 apt-get update 與 apt-get install 合併至同一行讓它不會被 cached 掉。

Resolved: #17 