### PR TITLE
讓 docker 使用 requirements 來安裝所需套件

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -13,7 +13,8 @@ RUN mkdir /etc/nuoj/storage/user_profile/
 RUN mkdir /etc/nuoj/storage/user_submission/
 RUN cp /etc/nuoj/setting/setting.json /etc/nuoj/setting.json
 
-RUN pip3 install flask pymysql flask_cors loguru flask_login flask_session asana python-dateutil pytz pyjwt pycryptodome
+WORKDIR /etc/nuoj
+RUN pip install -r requirements.txt
 
 WORKDIR /etc/nuoj/python
 CMD sleep 10 && flask --debug run --host 0.0.0.0 --port 8080


### PR DESCRIPTION
## What's new?

在這份 PR 中，我們讓 docker 使用 requirements.txt 來安裝所需的套件。