### PR TITLE
改用 sqlalchemy 來連接資料庫

### DIFF
--- a/python/app.py
+++ b/python/app.py
@@ -9,6 +9,7 @@ from app_add_problem import problem
 from app_auth import auth
 from app_problem import problem_page
 from app_profile import profile_page
+from database import create_db_command, db
 from page.route import page
 
 
@@ -20,6 +21,9 @@ def create_app(test_config: Mapping[str, Any] | None = None) -> Flask:
     else:
         app.config.from_mapping(test_config)
 
+    db.init_app(app)
+
+    app.cli.add_command(create_db_command)
     app.register_blueprint(auth)
     app.register_blueprint(problem)
     app.register_blueprint(problem_page)

--- a/python/config.py
+++ b/python/config.py
@@ -1,5 +1,12 @@
 import os
 from datetime import timedelta
+from urllib.parse import quote
 
 SECRET_KEY: str = os.urandom(24)
 PERMANENT_SESSION_LIFETIME = timedelta(days=31)
+
+SQLALCHEMY_DATABASE_URI: str = (
+    "mysql+pymysql://nuoja:{password}@mariadb:3306/nuoj".format(
+        password=quote("@nuoja2023")
+    )
+)

--- a/python/database/__init__.py
+++ b/python/database/__init__.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import sqlite3
+from typing import Final
+
+import click
+from flask import current_app
+from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+
+db: Final[SQLAlchemy] = SQLAlchemy()
+
+# For SQLAlchemy.create_all to know what to create.
+# NOTE: imports after the creation of "db" to resolve circular import
+from models import User
+
+
+# SQLite does not work with foreign key by default.
+# The PRAGMA for enablement must be emitted on all connections before use.
+# See https://docs.sqlalchemy.org/en/20/dialects/sqlite.html#foreign-key-support
+@event.listens_for(Engine, "connect")
+def set_sqlite_pragma(dbapi_connection, _):
+    if isinstance(dbapi_connection, sqlite3.Connection):
+        cursor: sqlite3.Cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+        
+@click.command("create-db")
+def create_db_command() -> None:
+    create_db()
+    click.echo("Created the database.")
+
+
+def create_db() -> None:
+    with current_app.app_context():
+        db.create_all()

--- a/python/models/__init__.py
+++ b/python/models/__init__.py
@@ -1,0 +1,11 @@
+from database import db
+
+class User(db.Model):
+    user_uid = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    handle = db.Column(db.String(32), unique=True)
+    password = db.Column(db.String(128), nullable=False)
+    email = db.Column(db.String(100), nullable=False)
+    role = db.Column(db.Integer, nullable=False)
+    email_verified = db.Column(db.Integer, nullable=False)
+    
+    __table_args__ = (db.CheckConstraint(email_verified.in_({0, 1})),)


### PR DESCRIPTION
## What's new

在這份 PR 中，我們使用 SQLAlchemy 來連接與存取資料庫。

## Setup database

在 `/python` 中，使用 `flask run create-db` 指令來設定資料庫。