### PR TITLE
新增 .coveragerc 來設定 pytest-cov

### DIFF
--- a/python/.coveragerc
+++ b/python/.coveragerc
@@ -1,0 +1,12 @@
+[run]
+branch = True
+omit = test/**/*.py
+
+[report]
+show_missing = True
+exclude_lines =
+  # Re-enable the standard pragma
+  pragma: no cover
+
+  # Type checking only
+  if TYPE_CHECKING:


### PR DESCRIPTION
## What's new?

新增了 `.coveragerc` 來設定 `pytest-cov`，包含了顯示 branch、忽略檔案與顯示 missing 的行數。