### PR TITLE
修復 email_util 不經由 setting_util 取得設定值而是直接讀檔

### DIFF
--- a/python/api/auth/email_util.py
+++ b/python/api/auth/email_util.py
@@ -68,13 +68,12 @@ def _put_parameter_to_mail_content(content: str, verification_url: str, username
     return content
 
 def _get_mail_sender() -> MailSender:
-    with open("/etc/nuoj/setting.json", "r") as file:
-        file_content = file.read()
-        setting_dict = json.loads(file_content)
-        mail_info = setting_dict["mail"]
-        mail_sender = MailSender(mail_info["server"], mail_info["port"], mail_info["mailname"], mail_info["password"])
-        
-        return mail_sender
+    setting: Setting = current_app.config.get("setting", None)
+    assert setting is not None
+    
+    mail_sender = MailSender(setting.mail_server(), setting.mail_port(), setting.mail_mailname(), setting.mail_password())
+    
+    return mail_sender
 
 def _get_logo_mime_image() -> MIMEImage:
     image_content: bytes

--- a/python/setting/util.py
+++ b/python/setting/util.py
@@ -66,6 +66,18 @@ class Setting():
         回傳使用者是否開啟信箱驗證功能
         '''
         return self.setting["mail"]["enable"]
+    
+    def mail_server(self) -> str:
+        return self.setting["mail"]["server"]
+
+    def mail_port(self) -> str:
+        return self.setting["mail"]["port"]
+    
+    def mail_mailname(self) -> str:
+        return self.setting["mail"]["mailname"]
+    
+    def mail_password(self) -> str:
+        return self.setting["mail"]["password"]
 
     def mail_info(self) -> str:
         return self.setting["mail"]["info"]

--- a/python/test/conftest.py
+++ b/python/test/conftest.py
@@ -30,10 +30,10 @@ def app() -> Generator[Flask, None, None]:
     )
     _setup_setting_to_app_config(app)
     _create_storage_folder_structure(storage_path)
-    _remove_all_email_from_fake_smtp_server()
     with app.app_context():
         create_db()
         _add_test_account()
+        _remove_all_email_from_fake_smtp_server()
     
     yield app
     


### PR DESCRIPTION
## What's happen?

在 `email_util` 中的 `_get_mail_sender` 取得設定值的方式是直接讀取檔案，而非從 `setting_util` 中取得，會導致使用了 production environment 的設定檔中的測試值而非測試定義的測試值。