### PR TITLE
修復 mail 遺失 redirected_url 欄位的問題

### DIFF
--- a/setting/setting.json
+++ b/setting/setting.json
@@ -20,6 +20,7 @@
         "server": "",
         "port": "",
         "mailname": "",
-        "password": ""
+        "password": "",
+        "redirect_url": ""
     }
 }


### PR DESCRIPTION
## What happen?

在 mail 欄位中，缺少了 redirect_url 欄位，導致 app 無法開啟成功。

## Note

預期 type-check 不會成功，因為還沒做型別修正。