### PR TITLE
調整 `/api/auth/verify_jwt` 接口回傳使 JWT 有效時回傳 JWT 資料

### DIFF
--- a/python/api/auth/api_route.py
+++ b/python/api/auth/api_route.py
@@ -128,7 +128,16 @@ def oauth_info_route() -> Response:
 @validate_jwt_is_exists_or_return_unauthorized
 @validate_jwt_is_valid_or_return_unauthorized
 def verify_jwt_route() -> Response:
-    response: Response = make_response({"message": "OK"}, HTTPStatus.OK)
+    jwt: str = request.cookies["jwt"]
+    key: str = current_app.config["jwt_key"]
+    codec: HS256JWTCodec = HS256JWTCodec(key)
+
+    jwt_payload: dict[str, Any] = codec.decode(jwt)
+    jwt_data_payload: dict[str, str] = jwt_payload["data"]
+
+    response: Response = make_response(
+        {"message": "OK", "data": jwt_data_payload}, HTTPStatus.OK
+    )
     return response
 
 

--- a/python/test/auth/test_api_route.py
+++ b/python/test/auth/test_api_route.py
@@ -362,6 +362,19 @@ class TestJWTVerifyRoute:
 
         assert response.status_code == HTTPStatus.OK
 
+    def test_with_valid_jwt_token_should_have_user_data_payload(
+        self, logged_in_client: FlaskClient
+    ):
+        response: TestResponse = logged_in_client.post("/api/auth/verify_jwt")
+
+        assert response.status_code == HTTPStatus.OK
+        assert response.json is not None
+        response_payload: dict[str, Any] = response.json
+        assert "data" in response_payload
+        user_data_payload: dict[str, str] = response_payload["data"]
+        assert user_data_payload["handle"] == "test_account"
+        assert user_data_payload["email"] == "test_account@nuoj.com"
+
     def test_with_not_exists_jwt_token_should_return_http_status_forbidden(
         self, client: FlaskClient
     ):


### PR DESCRIPTION
## What's new?

在這份 PR 中，我們調整了 `/api/auth/verify_jwt` 接口，使 JWT 有效時回傳 JWT 資料。