### PR TITLE
修復寄信系統不需要 JWT 與字典鍵問題

### DIFF
--- a/python/api/auth/api_route.py
+++ b/python/api/auth/api_route.py
@@ -220,8 +220,6 @@ def logout_route() -> Response:
 
 
 @auth_bp.route("/verify_mail", methods=["POST"])
-@validate_jwt_is_exists_or_return_unauthorized
-@validate_jwt_is_valid_or_return_unauthorized
 def verify_mail_route() -> Response:
     mail_verification_codes: dict[str, str] = current_app.config[
         "mail_verification_code"
@@ -237,15 +235,7 @@ def verify_mail_route() -> Response:
             HTTPStatus.UNPROCESSABLE_ENTITY, "Invalid code."
         )
 
-    jwt_token: str = request.cookies["jwt"]
-    codec: HS256JWTCodec = HS256JWTCodec(current_app.config["jwt_key"])
-    jwt_payload: dict[str, Any] = codec.decode(jwt_token)
-    handle: str = jwt_payload["data"]["handle"]
-
-    if handle != mail_verification_codes[code]:
-        return make_simple_error_response(
-            HTTPStatus.FORBIDDEN, "Code and handle is not match."
-        )
+    handle: str = mail_verification_codes[code]
 
     del mail_verification_codes[code]
     verified_the_email_of_handle(handle)

--- a/python/api/auth/email_util.py
+++ b/python/api/auth/email_util.py
@@ -21,12 +21,10 @@ class MailSender:
 
 
 def send_verification_email(username: str, email: str) -> None:
-    random_uuid: UUID = uuid4()
+    random_uuid: str = str(uuid4())
     mail_sender: MailSender = _get_mail_sender()
     logo_image: MIMEImage = _get_logo_mime_image()
-    mime_text_content: MIMEText = _get_mail_content_mime_text(
-        username, str(random_uuid)
-    )
+    mime_text_content: MIMEText = _get_mail_content_mime_text(username, random_uuid)
 
     mime_mail: MIMEMultipart = _build_verification_mail(
         [logo_image], "NuOJ 驗證信件", "NuOJ@noreply.me", email, mime_text_content

--- a/python/page/auth/route.py
+++ b/python/page/auth/route.py
@@ -16,3 +16,8 @@ def register_route():
 @auth_page.route("/handle_setup", methods=["GET"])
 def handle_setup():
     return render_template("handle_setup.html", **locals())
+
+
+@auth_page.route("/verify_mail", methods=["GET"])
+def verify_mail():
+    return render_template("verify_mail.html", **locals())


### PR DESCRIPTION
## What's problem?

在原先的寄信介面上，設置了「驗證 JWT 否則回傳 FORBIDDEN」的不合理機制，以及寄信功能上的鍵值為 UUID 實體而非字串。

在這份 PR 上針對了問題進行修復。