### PR TITLE
修復 Github 登入成功後不會有 HS cookie 的問題

### DIFF
--- a/python/api/auth/api_route.py
+++ b/python/api/auth/api_route.py
@@ -162,6 +162,7 @@ def github_login_route() -> WerkzeugResponse:
         user: User = _get_user_info_from_account(oauth_login_result.email)
         if user.handle is None:
             response = redirect("/handle_setup")
+            _set_cookie_to_response("hs", {"email": user.email}, response)
         else:
             response = redirect("/")
             _set_cookie_to_response(


### PR DESCRIPTION
## What's problem?

我們發現到了當 Github OAuth 成功登入後，使用者不會拿到 HS cookie 來成功設置 handle。

透過當使用者成功登入後，新增 hs cookie 來修復這個問題。