### PR TITLE
將 auth 未覆蓋測試的程式碼新增測試與修復

### DIFF
--- a/python/api/auth/api_route.py
+++ b/python/api/auth/api_route.py
@@ -180,7 +180,7 @@ def google_login_route() -> WerkzeugResponse:
     error: str | None = request.args.get("error")
 
     if error is not None:
-        make_simple_error_response(
+        return make_simple_error_response(
             HTTPStatus.FORBIDDEN,
             "Google OAuth login failed since args have error argument.",
         )
@@ -188,7 +188,7 @@ def google_login_route() -> WerkzeugResponse:
     code: str | None = request.args.get("code")
 
     if code is None:
-        make_simple_error_response(
+        return make_simple_error_response(
             HTTPStatus.BAD_REQUEST,
             "Absent code.",
         )


### PR DESCRIPTION
## What's new?

在這份 PR 上，我們將 auth 未覆蓋測試的程式碼新增測試與修復，包含了以下兩件事情：

 - 修復 Google OAuth Login 在 code parameter 不存在時應回傳 400，error parameter 存在時須回傳 403。
 - 修復 logout 測試