### PR TITLE
完成 `/setup_handle` 頁面的調整

### DIFF
--- a/templates/handle_setup.html
+++ b/templates/handle_setup.html
@@ -44,16 +44,21 @@
             dataJson["handle"] = handle;
             console.log(handle)
             $.ajax({
-                    url: "./handle-setup",
+                    url: "/api/auth/setup_handle",
                     type: "POST",
                     data: JSON.stringify(dataJson),
                     dataType: "json",
                     contentType: "application/json",
                     success: function(data, status, xhr){
-                        if(data["status"] == "OK"){
-                            success_swal("設置成功").then(() => {window.location.href = "/"})
-                        }else{
-                            error_swal("設置失敗", data["code"])
+                        success_swal("設置成功").then(() => {window.location.href = "/"})
+                    },
+                    error: function(xhr, exception){
+                        if(xhr.status == 401){
+                            error_swal("設置失敗", "HS_INVALID")
+                        }else if(xhr.status == 422){
+                            error_swal("設置失敗", "Handle 不符合規範")
+                        }else if(xhr.status == 403){
+                            error_swal("設置失敗", "Handle 已重複")
                         }
                     }
             });


### PR DESCRIPTION
## What's new?

在這份 PR 中，我們對於 `/setup_handle` 頁面進行調整，使其能夠介接至後端的 API 並能夠正常的為使用者設定 handle。