### PR TITLE
新增題目頁面介面至後端

### DIFF
--- a/python/app.py
+++ b/python/app.py
@@ -11,6 +11,7 @@ from api.problem.route import problem_bp
 from api.auth.test_route import auth_test_bp
 from database import create_db_command, db
 from page.auth.route import auth_page
+from page.problem.route import problem_page_bp
 from page.route import page
 from setting.util import Setting, SettingBuilder
 
@@ -37,6 +38,7 @@ def create_app(test_config: Mapping[str, Any] | None = None) -> Flask:
     app.register_blueprint(auth_test_bp)
     app.register_blueprint(auth_page)
     app.register_blueprint(page)
+    app.register_blueprint(problem_page_bp)
 
     @app.route("/static/<path:path>")
     def fetch_static_file_from_specific_path(path):

--- a/python/page/problem/route.py
+++ b/python/page/problem/route.py
@@ -1,0 +1,13 @@
+from flask import Blueprint, render_template
+
+problem_page_bp = Blueprint("problem_page", __name__)
+
+
+@problem_page_bp.route("/problem", methods=["GET"])
+def fetch_problem_list_page_route():
+    return render_template("problem_list.html", **locals())
+
+
+@problem_page_bp.route("/problem/<int:id>", methods=["GET"])
+def fetch_problem_info_page_route(id: int):
+    return render_template("problem_info.html", **locals())


### PR DESCRIPTION
## What's new?

在這份 PR 中，我們新增了題目頁面介面至後端，讓前端能夠使用兩個不同的檔名來施工。

 - 針對於題目列表：`problem_list.html`
 - 針對於題目內容：`problem_info.html`

由於頁面還沒有 test mark，故移到前端完成 test mark 後加上測試。