### PR TITLE
修復 Google OAuth 按鈕錯誤呈現的問題

### DIFF
--- a/src/js/login.jsx
+++ b/src/js/login.jsx
@@ -51,7 +51,7 @@ class LoginButton extends React.Component {
         if(github_oauth_url != null){
             render_component.push(github_submit)
         }
-        if(google_submit != null){
+        if(google_oauth_url != null){
             render_component.push(google_submit)
         }
         if(status == null){

--- a/src/js/register.jsx
+++ b/src/js/register.jsx
@@ -40,7 +40,7 @@ class RegisterButton extends React.Component {
         if(github_oauth_url != null){
             render_component.push(github_submit)
         }
-        if(google_submit != null){
+        if(google_oauth_url != null){
             render_component.push(google_submit)
         }
         if(status == null){

--- a/static/js/login.js
+++ b/static/js/login.js
@@ -91,7 +91,7 @@ var LoginButton = function (_React$Component) {
             if (github_oauth_url != null) {
                 render_component.push(github_submit);
             }
-            if (google_submit != null) {
+            if (google_oauth_url != null) {
                 render_component.push(google_submit);
             }
             if (status == null) {

--- a/static/js/register.js
+++ b/static/js/register.js
@@ -81,7 +81,7 @@ var RegisterButton = function (_React$Component) {
             if (github_oauth_url != null) {
                 render_component.push(github_submit);
             }
-            if (google_submit != null) {
+            if (google_oauth_url != null) {
                 render_component.push(google_submit);
             }
             if (status == null) {


### PR DESCRIPTION
## What happened?

在這份 PR 中，我修復了 Google OAuth 按鈕錯誤呈現的問題，當 `/api/auth/oauth_info` 界面沒有呈現 `google_oauth` 登入資料的情況時，按鈕依然會呈現在登入頁面上。

## How to review?

預設情況時 `setting.json` 中的 `google_oauth` 會是打開的，請關掉之後嘗試重開 Application，再回到登入頁面確認。
 - setting.json 在哪裡：在專案根目錄上。
 - 如何重開 Application：對 app.py 做存檔的動作，Flask 會偵測到變更然後重啟 Application。