### PR TITLE
調整 `profile` 頁面的 payload 格式

### DIFF
--- a/src/js/react_profile_guest.jsx
+++ b/src/js/react_profile_guest.jsx
@@ -85,18 +85,26 @@ class Introduce extends React.Component {
     var location = window.location.href.split("/")
     const handle = location[location.length-1] 
 
-        fetch("/get_profile/"+handle).then((res)=>{
-            return res.json()
-        }).then((json)=>{
-            const status = json.status;
-            if( status == "OK"){
-                this.setState({profile_data : json.data})
-            }
-            else{
-                error_swal("請先登入").then(() => {window.location.href = "/" })
-            }
-        })
-        
+    fetch("/api/profile/" + handle).then((response) => {
+        if(response.ok){
+            response.json().then((json) => {
+                console.log(json)
+                let profile_data = {
+                    main: {
+                        img: "/api/profile/" + handle + "/avatar",
+                        handle: handle,
+                        accountType: json.role // Should be supported in API but not yet implement.
+                    },
+                    sub: {
+                        email: json.email,
+                        school: json.school,
+                        bio: json.bio
+                    }
+                }
+                this.setState({profile_data: profile_data, mode: false})
+            })  
+        }
+    })
     }
     
     update_profile(i){

--- a/src/js/react_profile_guest.jsx
+++ b/src/js/react_profile_guest.jsx
@@ -93,7 +93,7 @@ class Introduce extends React.Component {
                     main: {
                         img: "/api/profile/" + handle + "/avatar",
                         handle: handle,
-                        accountType: json.role // Should be supported in API but not yet implement.
+                        accountType: json.role
                     },
                     sub: {
                         email: json.email,

--- a/src/js/react_profile_guest.jsx
+++ b/src/js/react_profile_guest.jsx
@@ -100,7 +100,7 @@ class Introduce extends React.Component {
                         bio: json.bio
                     }
                 }
-                this.setState({profile_data: profile_data, mode: false})
+                this.setState({profile_data: profile_data})
             })  
         }
     })

--- a/src/js/react_profile_guest.jsx
+++ b/src/js/react_profile_guest.jsx
@@ -70,7 +70,6 @@ class Introduce extends React.Component {
                     bio : ""
                 }
             },
-            mode : false
         }
         this.changing_mode = this.change_mode.bind(this)
         this.get_profile = this.get_profile.bind(this)

--- a/static/js/react_profile_guest.js
+++ b/static/js/react_profile_guest.js
@@ -116,8 +116,7 @@ var Introduce = function (_React$Component2) {
                     school: "",
                     bio: ""
                 }
-            },
-            mode: false
+            }
         };
         _this2.changing_mode = _this2.change_mode.bind(_this2);
         _this2.get_profile = _this2.get_profile.bind(_this2);

--- a/static/js/react_profile_guest.js
+++ b/static/js/react_profile_guest.js
@@ -153,7 +153,7 @@ var Introduce = function (_React$Component2) {
                                 bio: json.bio
                             }
                         };
-                        _this3.setState({ profile_data: profile_data, mode: false });
+                        _this3.setState({ profile_data: profile_data });
                     });
                 }
             });

--- a/static/js/react_profile_guest.js
+++ b/static/js/react_profile_guest.js
@@ -146,7 +146,7 @@ var Introduce = function (_React$Component2) {
                             main: {
                                 img: "/api/profile/" + handle + "/avatar",
                                 handle: handle,
-                                accountType: json.role // Should be supported in API but not yet implement.
+                                accountType: json.role
                             },
                             sub: {
                                 email: json.email,

--- a/static/js/react_profile_guest.js
+++ b/static/js/react_profile_guest.js
@@ -138,15 +138,23 @@ var Introduce = function (_React$Component2) {
             var location = window.location.href.split("/");
             var handle = location[location.length - 1];
 
-            fetch("/get_profile/" + handle).then(function (res) {
-                return res.json();
-            }).then(function (json) {
-                var status = json.status;
-                if (status == "OK") {
-                    _this3.setState({ profile_data: json.data });
-                } else {
-                    error_swal("請先登入").then(function () {
-                        window.location.href = "/";
+            fetch("/api/profile/" + handle).then(function (response) {
+                if (response.ok) {
+                    response.json().then(function (json) {
+                        console.log(json);
+                        var profile_data = {
+                            main: {
+                                img: "/api/profile/" + handle + "/avatar",
+                                handle: handle,
+                                accountType: json.role // Should be supported in API but not yet implement.
+                            },
+                            sub: {
+                                email: json.email,
+                                school: json.school,
+                                bio: json.bio
+                            }
+                        };
+                        _this3.setState({ profile_data: profile_data, mode: false });
                     });
                 }
             });


### PR DESCRIPTION
## What's new?

在這份 PR 中，我們嘗試調整 `profile` 頁面的 payload 格式，將格式設置成最新的 `/api/profile/<name>` 中的 Payload。