### PR TITLE
在 Build Phase 不初始化資料庫

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,6 @@ services:
       MYSQL_DATABASE: nuoj
       MYSQL_ROOT_USER: root
       MYSQL_ROOT_PASSWORD: "#nuojr2023"
-    volumes:
-      - ./database.sql:/docker-entrypoint-initdb.d/init.sql
     ports:
       - "3306:3306"
   mariadb-test:


### PR DESCRIPTION
## What's new?

因為現在的 schema 是舊的，為了能夠保持一致性，先把資料庫交給使用者手動初始化。