### PR TITLE
修復 strict slash 導致請求重新導向的問題

### DIFF
--- a/python/app.py
+++ b/python/app.py
@@ -37,6 +37,7 @@ def create_app(test_config: Mapping[str, Any] | None = None) -> Flask:
 
     db.init_app(app)
 
+    app.url_map.strict_slashes = False
     app.cli.add_command(create_db_command)
     app.register_blueprint(auth_bp)
     app.register_blueprint(problem_bp)


### PR DESCRIPTION
## What's happened

由於不加 slash 至結尾時會導致 307，在此解除限制。